### PR TITLE
[DNA-21300]: Redash Deprecation Banner

### DIFF
--- a/client/app/components/DeprecationBanner/index.jsx
+++ b/client/app/components/DeprecationBanner/index.jsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from "react";
+import ExclamationCircleFilled from "@ant-design/icons/ExclamationCircleFilled";
+import CloseOutlined from "@ant-design/icons/CloseOutlined";
+
+import "./index.less";
+
+function DeprecationBanner() {
+  const [showBanner, setShowBanner] = useState(true);
+
+  useEffect(() => {
+    const dismissedTimestamp = localStorage.getItem('banner_dismissed');
+    if (dismissedTimestamp) {
+      const dismissedDate = new Date(parseInt(dismissedTimestamp, 10));
+      const currentDate = new Date();
+      if (dismissedDate.toDateString() === currentDate.toDateString()) {
+        setShowBanner(false);
+      }
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    const currentTimestamp = new Date().getTime();
+    localStorage.setItem('banner_dismissed', currentTimestamp.toString());
+    setShowBanner(false);
+  };
+
+  if (!showBanner) {
+    return null;
+  }
+
+  return (
+    <div className="deprecation-banner">
+      <div className="banner-content">
+        <ExclamationCircleFilled className="warning-icon" />
+        <div className="banner-text">
+          Redash will be deprecated by {' '}<strong>June 2025.</strong>
+          For more queries and support, please connect with us on slack at{' '}
+          <span className="support-channel">#careem-insights-support</span>
+        </div>
+      </div>
+      <CloseOutlined
+        className="close-button"
+        onClick={handleDismiss}
+      />
+    </div>
+  );
+}
+
+export default DeprecationBanner;

--- a/client/app/components/DeprecationBanner/index.less
+++ b/client/app/components/DeprecationBanner/index.less
@@ -1,0 +1,59 @@
+.deprecation-banner {
+  background-color: rgba(255, 77, 79, 0.1);
+  color: #cf1322;
+  padding: 11px;
+  font-size: 16px;
+  font-family: Inter, Helvetica, Arial;
+  margin: 9px 0 9px 0;
+  border-radius: 5px;
+  border: 1px solid #ff4d4f;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .banner-content {
+    display: flex;
+    align-items: center;
+  }
+
+  .warning-icon {
+    font-size: 24px;
+    margin-right: 15px;
+  }
+
+  .banner-text {
+    text-align: left;
+    align-items: center;
+  }
+
+  strong {
+    font-weight: bold;
+    margin-right: 10px;
+  }
+
+  em {
+    font-style: italic;
+    font-weight: bold;
+  }
+
+  .support-channel {
+    color: #cf1322;
+    font-weight: bold;
+  }
+
+  .close-button {
+    cursor: pointer;
+    font-size: 18px;
+    color: #cf1322;
+    opacity: 0.7;
+    transition: opacity 0.3s ease;
+    padding: 5px;
+    border-radius: 50%;
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .close-button:hover {
+    opacity: 1;
+    background-color: rgba(255, 255, 255, 0.4);
+  }
+}

--- a/client/app/components/PageHeader/index.jsx
+++ b/client/app/components/PageHeader/index.jsx
@@ -2,13 +2,17 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import "./index.less";
+import DeprecationBanner from "../DeprecationBanner";
 
 export default function PageHeader({ title, actions }) {
   return (
-    <div className="page-header-wrapper">
-      <h3>{title}</h3>
-      {actions && <div className="page-header-actions">{actions}</div>}
-    </div>
+    <>
+      <DeprecationBanner />
+      <div className="page-header-wrapper">
+        <h3>{title}</h3>
+        {actions && <div className="page-header-actions">{actions}</div>}
+      </div>
+    </>
   );
 }
 

--- a/client/app/pages/alert/components/Title.jsx
+++ b/client/app/pages/alert/components/Title.jsx
@@ -6,30 +6,34 @@ import { getDefaultName } from "../Alert";
 import { Alert as AlertType } from "@/components/proptypes";
 
 import "./Title.less";
+import DeprecationBanner from "@/components/DeprecationBanner";
 
 export default function Title({ alert, editMode, name, onChange, children }) {
   const defaultName = getDefaultName(alert);
   return (
-    <div className="alert-header">
-      <div className="alert-title">
-        <h3>
-          {editMode && alert.query ? (
-            // BUG: Input is not the same width as the container
-            // TODO: consider adding a label (not obvious for sighted users)
-            <Input
-              className="f-inherit"
-              placeholder={defaultName}
-              value={name}
-              aria-label="Alert title"
-              onChange={e => onChange(e.target.value)}
-            />
-          ) : (
-            name || defaultName
-          )}
-        </h3>
+    <>
+      <DeprecationBanner />
+      <div className="alert-header">
+        <div className="alert-title">
+          <h3>
+            {editMode && alert.query ? (
+              // BUG: Input is not the same width as the container
+              // TODO: consider adding a label (not obvious for sighted users)
+              <Input
+                className="f-inherit"
+                placeholder={defaultName}
+                value={name}
+                aria-label="Alert title"
+                onChange={e => onChange(e.target.value)}
+              />
+            ) : (
+              name || defaultName
+            )}
+          </h3>
+        </div>
+        <div className="alert-actions">{children}</div>
       </div>
-      <div className="alert-actions">{children}</div>
-    </div>
+    </>
   );
 }
 

--- a/client/app/pages/dashboards/DashboardList.jsx
+++ b/client/app/pages/dashboards/DashboardList.jsx
@@ -22,7 +22,6 @@ import { currentUser } from "@/services/auth";
 import routes from "@/services/routes";
 
 import DashboardListEmptyState from "./components/DashboardListEmptyState";
-import DeprecationBanner from "@/components/DeprecationBanner";
 
 import "./dashboard-list.css";
 
@@ -92,7 +91,6 @@ function DashboardList({ controller }) {
   return (
     <div className="page-dashboard-list">
       <div className="container">
-        {controller?.params?.currentPage === "all" && <DeprecationBanner />}
         <PageHeader
           title={controller.params.pageTitle}
           actions={

--- a/client/app/pages/dashboards/DashboardList.jsx
+++ b/client/app/pages/dashboards/DashboardList.jsx
@@ -22,6 +22,7 @@ import { currentUser } from "@/services/auth";
 import routes from "@/services/routes";
 
 import DashboardListEmptyState from "./components/DashboardListEmptyState";
+import DeprecationBanner from "@/components/DeprecationBanner";
 
 import "./dashboard-list.css";
 
@@ -91,6 +92,7 @@ function DashboardList({ controller }) {
   return (
     <div className="page-dashboard-list">
       <div className="container">
+        {controller?.params?.currentPage === "all" && <DeprecationBanner />}
         <PageHeader
           title={controller.params.pageTitle}
           actions={

--- a/client/app/pages/dashboards/components/DashboardHeader.jsx
+++ b/client/app/pages/dashboards/components/DashboardHeader.jsx
@@ -20,6 +20,7 @@ import { durationHumanize } from "@/lib/utils";
 import { DashboardStatusEnum } from "../hooks/useDashboard";
 
 import "./DashboardHeader.less";
+import DeprecationBanner from "@/components/DeprecationBanner";
 
 function getDashboardTags() {
   return getTags("api/dashboards/tags").then(tags => map(tags, t => t.name));
@@ -286,10 +287,14 @@ export default function DashboardHeader({ dashboardConfiguration, headerExtra })
   const DashboardControlComponent = editingLayout ? DashboardEditControl : DashboardControl;
 
   return (
-    <div className="dashboard-header">
-      <DashboardPageTitle dashboardConfiguration={dashboardConfiguration} />
-      <DashboardControlComponent dashboardConfiguration={dashboardConfiguration} headerExtra={headerExtra} />
-    </div>
+    <>
+      <DeprecationBanner />
+      <div className="dashboard-header">
+        <DashboardPageTitle dashboardConfiguration={dashboardConfiguration} />
+        <DashboardControlComponent dashboardConfiguration={dashboardConfiguration} headerExtra={headerExtra} />
+      </div>
+    </>
+
   );
 }
 

--- a/client/app/pages/home/Home.jsx
+++ b/client/app/pages/home/Home.jsx
@@ -16,6 +16,7 @@ import notification from "@/services/notification";
 import routes from "@/services/routes";
 
 import { DashboardAndQueryFavoritesList } from "./components/FavoritesList";
+import DeprecationBanner from "@/components/DeprecationBanner";
 
 import "./Home.less";
 
@@ -74,6 +75,9 @@ export default function Home() {
   return (
     <div className="home-page">
       <div className="container">
+        <div className="banner-margin">
+          <DeprecationBanner />
+        </div>
         {includes(messages, "using-deprecated-embed-feature") && <DeprecatedEmbedFeatureAlert />}
         {includes(messages, "email-not-verified") && <EmailNotVerifiedAlert />}
         <DynamicComponent name="Home.EmptyState">

--- a/client/app/pages/home/Home.less
+++ b/client/app/pages/home/Home.less
@@ -5,3 +5,7 @@
 .home-favorites-list {
   margin-top: -20px;
 }
+
+.banner-margin {
+  margin-top: -15px
+}

--- a/client/app/pages/queries/components/QueryPageHeader.jsx
+++ b/client/app/pages/queries/components/QueryPageHeader.jsx
@@ -23,6 +23,7 @@ import useApiKeyDialog from "../hooks/useApiKeyDialog";
 import usePermissionsEditorDialog from "../hooks/usePermissionsEditorDialog";
 
 import "./QueryPageHeader.less";
+import DeprecationBanner from "@/components/DeprecationBanner";
 
 function getQueryTags() {
   return getTags("api/queries/tags").then(tags => map(tags, t => t.name));
@@ -34,7 +35,7 @@ function createMenu(menu) {
   const groups = map(menu, group =>
     filter(
       map(group, (props, key) => {
-        props = extend({ isAvailable: true, isEnabled: true, onClick: () => {} }, props);
+        props = extend({ isAvailable: true, isEnabled: true, onClick: () => { } }, props);
         if (props.isAvailable) {
           handlers[key] = props.onClick;
           return (
@@ -147,65 +148,69 @@ export default function QueryPageHeader({
   );
 
   return (
-    <div className="query-page-header">
-      <div className="title-with-tags">
-        <div className="page-title">
-          <div className="d-flex align-items-center">
-            {!queryFlags.isNew && <FavoritesControl item={query} />}
-            <h3>
-              <EditInPlace isEditable={queryFlags.canEdit} onDone={updateName} ignoreBlanks value={query.name} />
-            </h3>
+    <>
+      <DeprecationBanner />
+      <div className="query-page-header">
+        <div className="title-with-tags">
+          <div className="page-title">
+            <div className="d-flex align-items-center">
+              {!queryFlags.isNew && <FavoritesControl item={query} />}
+              <h3>
+                <EditInPlace isEditable={queryFlags.canEdit} onDone={updateName} ignoreBlanks value={query.name} />
+              </h3>
+            </div>
+          </div>
+          <div className="query-tags">
+            <QueryTagsControl
+              tags={query.tags}
+              isDraft={queryFlags.isDraft}
+              isArchived={queryFlags.isArchived}
+              canEdit={queryFlags.canEdit}
+              getAvailableTags={getQueryTags}
+              onEdit={updateTags}
+              tagsExtra={tagsExtra}
+            />
           </div>
         </div>
-        <div className="query-tags">
-          <QueryTagsControl
-            tags={query.tags}
-            isDraft={queryFlags.isDraft}
-            isArchived={queryFlags.isArchived}
-            canEdit={queryFlags.canEdit}
-            getAvailableTags={getQueryTags}
-            onEdit={updateTags}
-            tagsExtra={tagsExtra}
-          />
+        <div className="header-actions">
+          {headerExtra}
+          {isDesktop && queryFlags.isDraft && !queryFlags.isArchived && !queryFlags.isNew && queryFlags.canEdit && (
+            <Button className="m-r-5" onClick={publishQuery}>
+              <i className="fa fa-paper-plane m-r-5" aria-hidden="true" /> Publish
+            </Button>
+          )}
+
+          {!queryFlags.isNew && queryFlags.canViewSource && (
+            <span>
+              {!sourceMode && (
+                <Link.Button className="m-r-5" href={query.getUrl(true, selectedVisualization)}>
+                  <i className="fa fa-pencil-square-o" aria-hidden="true" />
+                  <span className="m-l-5">Edit Source</span>
+                </Link.Button>
+              )}
+              {sourceMode && (
+                <Link.Button
+                  className="m-r-5"
+                  href={query.getUrl(false, selectedVisualization)}
+                  data-test="QueryPageShowResultOnly">
+                  <i className="fa fa-table" aria-hidden="true" />
+                  <span className="m-l-5">Show Results Only</span>
+                </Link.Button>
+              )}
+            </span>
+          )}
+
+          {!queryFlags.isNew && (
+            <Dropdown overlay={moreActionsMenu} trigger={["click"]}>
+              <Button data-test="QueryPageHeaderMoreButton" aria-label="More actions">
+                <EllipsisOutlinedIcon rotate={90} aria-hidden="true" />
+              </Button>
+            </Dropdown>
+          )}
         </div>
       </div>
-      <div className="header-actions">
-        {headerExtra}
-        {isDesktop && queryFlags.isDraft && !queryFlags.isArchived && !queryFlags.isNew && queryFlags.canEdit && (
-          <Button className="m-r-5" onClick={publishQuery}>
-            <i className="fa fa-paper-plane m-r-5" aria-hidden="true" /> Publish
-          </Button>
-        )}
+    </>
 
-        {!queryFlags.isNew && queryFlags.canViewSource && (
-          <span>
-            {!sourceMode && (
-              <Link.Button className="m-r-5" href={query.getUrl(true, selectedVisualization)}>
-                <i className="fa fa-pencil-square-o" aria-hidden="true" />
-                <span className="m-l-5">Edit Source</span>
-              </Link.Button>
-            )}
-            {sourceMode && (
-              <Link.Button
-                className="m-r-5"
-                href={query.getUrl(false, selectedVisualization)}
-                data-test="QueryPageShowResultOnly">
-                <i className="fa fa-table" aria-hidden="true" />
-                <span className="m-l-5">Show Results Only</span>
-              </Link.Button>
-            )}
-          </span>
-        )}
-
-        {!queryFlags.isNew && (
-          <Dropdown overlay={moreActionsMenu} trigger={["click"]}>
-            <Button data-test="QueryPageHeaderMoreButton" aria-label="More actions">
-              <EllipsisOutlinedIcon rotate={90} aria-hidden="true" />
-            </Button>
-          </Dropdown>
-        )}
-      </div>
-    </div>
   );
 }
 
@@ -229,5 +234,5 @@ QueryPageHeader.defaultProps = {
   selectedVisualization: null,
   headerExtra: null,
   tagsExtra: null,
-  onChange: () => {},
+  onChange: () => { },
 };


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

### DNA-21300
**Problem**
The redash has planned to be deprecated by June 2025. The users must be informed prior, to make a transition to careem insights effectively
_Solution_: Adding a banner to the Redash Home screen 

**Technical Details**
- [x] Adding a new deprecation banner component including the banner information and support channel in `client/app/components/DeprecationBanner/index.jsx` and `client/app/components/DeprecationBanner/index.less`
- [x] Rendering the `<DeprecationBanner/>` banner on **Dashboard** and **HomePage** as Dashboard list is the default page for every logged in user.
- [x] Implementing dismiss condition using Storage, once dismissed the banner will be silent for today should re-appear the following day.

**Testing Steps:**
- The banner should appear for every user on Home Screen and DashboardList Screen
- The cross button should dismiss the banner
- The banner should not appear the entire day, once dismissed
- The banner should re-appear the next day

### DNA-21496
**Problem**
Previously the deprecation banner was only displayed on Home & Dashboard Screen

**Solution:** 
Adding a banner to the Redash App Component. So, that it is visible to every screen and visible via direct links [queries & alerts]

**Technical Details**
- [x] Rendering the <DeprecationBanner/> banner in  List Components i.e in `client/app/components/PageHeader/index.jsx`
- [x] Rendering the <DeprecationBanner/> banner in specific linked components like Alerts, Queries, Dashboards i.e in `client/app/pages/alert/components/Title.jsx, client/app/pages/queries/components/QueryPageHeader.jsx and client/app/pages/dashboards/components/DashboardHeader.jsx` respectively
- [x] Removing the banner from child components Dashboard Page i.e. `DashboardList.jsx.`

Testing
The banner should appear for every user on every screen
The banner should also appear on the query  dashboard via direct Link
The cross button should dismiss the banner
The banner should not appear the entire day, once dismissed
The banner should re-appear the next day

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**DNA- 21300**
<img width="1800" alt="Screenshot 2024-10-14 at 2 25 10 PM" src="https://github.com/user-attachments/assets/c3198dea-3eaf-40fe-98f3-cb71899db006">

<img width="1798" alt="Screenshot 2024-10-14 at 2 25 03 PM" src="https://github.com/user-attachments/assets/e74c82f9-ff0d-4da8-97ac-e318772b8875">

**DNA-21496**

<img width="1796" alt="Screenshot 2024-10-20 at 3 59 48 AM" src="https://github.com/user-attachments/assets/5066a173-5496-47db-8bcb-ea4b09a6e919">
<img width="1799" alt="Screenshot 2024-10-20 at 3 59 56 AM" src="https://github.com/user-attachments/assets/852b9b7d-c118-4f9a-91ac-c1ee500aee35">
<img width="1796" alt="Screenshot 2024-10-20 at 4 00 03 AM" src="https://github.com/user-attachments/assets/3fbbcbe2-9415-4127-a9aa-da9bbe040e46">

