### PR TITLE
[DNA-23181]: Disable Creation of dashboard on Redash

### DIFF
--- a/client/app/components/DeprecationBanner/index.jsx
+++ b/client/app/components/DeprecationBanner/index.jsx
@@ -33,8 +33,7 @@ function DeprecationBanner() {
       <div className="banner-content">
         <ExclamationCircleFilled className="warning-icon" />
         <div className="banner-text">
-          Redash will be deprecated by {' '}<strong>June 2025.</strong>
-          For more queries and support, please connect with us on slack at{' '}
+          Redash will be deprecated by {' '}<strong>June 2025.</strong>Creation of new dashboards has been disabled, and creation of alerts/queries will be disabled soon. Please migrate your assets to <strong>Careem Insights</strong> and for more queries: Please reach out to us on Slack at{' '}
           <span className="support-channel">#careem-insights-support</span>
         </div>
       </div>

--- a/client/app/components/DeprecationBanner/index.less
+++ b/client/app/components/DeprecationBanner/index.less
@@ -1,8 +1,8 @@
 .deprecation-banner {
   background-color: rgba(255, 77, 79, 0.1);
   color: #cf1322;
-  padding: 11px;
-  font-size: 16px;
+  padding: 8px;
+  font-size: 13px;
   font-family: Inter, Helvetica, Arial;
   margin: 9px 0 9px 0;
   border-radius: 5px;
@@ -28,7 +28,7 @@
 
   strong {
     font-weight: bold;
-    margin-right: 10px;
+    margin-right: 4px;
   }
 
   em {

--- a/client/app/components/empty-state/EmptyState.jsx
+++ b/client/app/components/empty-state/EmptyState.jsx
@@ -155,18 +155,6 @@ function EmptyState({
       ),
     },
     {
-      key: "dashboards",
-      node: (
-        <Step
-          key="dashboards"
-          show={isAvailable.dashboard}
-          completed={isCompleted.dashboard}
-          onClick={showCreateDashboardDialog}
-          urlText="Create your first Dashboard"
-        />
-      ),
-    },
-    {
       key: "users",
       node: (
         <Step
@@ -233,7 +221,7 @@ EmptyState.defaultProps = {
   header: null,
   helpMessage: null,
   closable: false,
-  onClose: () => {},
+  onClose: () => { },
 
   onboardingMode: false,
   showAlertStep: false,

--- a/setup/README.md
+++ b/setup/README.md
@@ -2,4 +2,5 @@
 
 The setup script moved to its own repository:
 
+
 [https://github.com/getredash/setup](https://github.com/getredash/setup)

--- a/setup/README.md
+++ b/setup/README.md
@@ -2,5 +2,4 @@
 
 The setup script moved to its own repository:
 
-
 [https://github.com/getredash/setup](https://github.com/getredash/setup)


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

### DNA-23181
**Problem**
The users are able to create dashboards on Redash
_Solution_: Write a script for Revoking permission ‘create_dashboard’ from each group/role So that the users won’t be able to create new dashboards on Redash

**Technical Details**
writing a python script for:
- Creation of DB connection to Redash
- Providing choices to remove/restore the permission to the table (groups) and specific column (permissions)

For removal:
- Create a table data backup
- Verifying if any record exists containing ‘create_dashbaord’ permission
- Remove/Revoke the above permission against each group/role

For restoration:
- Restore table data backup OR
- Select Restoration of permission against each record/group
- The script should have configurable values for DB connections, table, column & permission. 
- So that it can be utilised for the removal of create_alerts & create_queries as well

**Testing Steps:**
- The removal step in the script should be able to make connection to the dashboard successfully
- Backup the "groups" data as csv
- Remove the permission "create_dashbaord" against each record (if exists) in the groups table
- The restorations steps should be able to revert the permission change against each record in groups table

### DNA-23222
**Problem**
The creation of dashboard has been disabled and should be informed to the users via Redash

**Solution:** 
Updating the banner content including the latest announcements

**Technical Details**
- [x] Updating the deprecation banner content in <DeprecationBanner/> component in `client/app/components/PageHeader/index.jsx`
- [x] Removing the menuItem "Create first Dashbaord" from <EmptyState/> component in `client/app/components/empty-state/EmptyState.jsx`

**Testing Steps**
The banner should appear for every user on every screen
The cross button should dismiss the banner
The banner should re-appear the next day
The banner content should include latest announcement on (creation of new dashboards are disabled)
If not dashboard exists against a user:
The **Create first dashboard** link should not appear for the user

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

**DNA-23222**
<img width="1796" alt="Screenshot 2025-02-19 at 12 55 41 PM" src="https://github.com/user-attachments/assets/05edf814-238c-40d4-8857-17bc4cde2a9b" />

<img width="1796" alt="Screenshot 2025-02-19 at 12 55 16 PM" src="https://github.com/user-attachments/assets/2ab03b79-d6f5-443a-988a-64df1fa940fc" />

**DNA-23181**

<img width="1798" alt="Screenshot 2025-02-18 at 11 52 58 AM" src="https://github.com/user-attachments/assets/90d0c009-1457-4a8c-9bb5-c484a941240a" />

<img width="1800" alt="Screenshot 2025-02-18 at 11 51 43 AM" src="https://github.com/user-attachments/assets/0dcf9be0-6094-4160-bc92-03b77070d77e" />
