### PR TITLE
[DNA-23591]: Disable creation of Alerts

### DIFF
--- a/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
@@ -69,7 +69,7 @@ export default function DesktopNavbar() {
 
   const canCreateQuery = currentUser.hasPermission("create_query");
   const canCreateDashboard = currentUser.hasPermission("create_dashboard");
-  const canCreateAlert = currentUser.hasPermission("create_alerts");
+  const canCreateAlert = currentUser.hasPermission("create_alert");
 
   return (
     <nav className="desktop-navbar">

--- a/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
@@ -56,7 +56,7 @@ function useNavbarActiveState() {
         currentRoute.id
       ),
       dataSources: includes(["DataSources.List"], currentRoute.id),
-      alerts: includes(["Alerts.List", "Alerts.New", "Alerts.View", "Alerts.Edit"], currentRoute.id),
+      alerts: includes(["Alerts.List", "Alerts.New", "Alerts.View"], currentRoute.id),
     }),
     [currentRoute.id]
   );
@@ -69,7 +69,7 @@ export default function DesktopNavbar() {
 
   const canCreateQuery = currentUser.hasPermission("create_query");
   const canCreateDashboard = currentUser.hasPermission("create_dashboard");
-  const canCreateAlert = currentUser.hasPermission("list_alerts");
+  const canCreateAlert = currentUser.hasPermission("create_alerts");
 
   return (
     <nav className="desktop-navbar">

--- a/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
+++ b/client/app/components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx
@@ -56,7 +56,7 @@ function useNavbarActiveState() {
         currentRoute.id
       ),
       dataSources: includes(["DataSources.List"], currentRoute.id),
-      alerts: includes(["Alerts.List", "Alerts.New", "Alerts.View"], currentRoute.id),
+      alerts: includes(["Alerts.List", "Alerts.New", "Alerts.View", "Alerts.Edit"], currentRoute.id),
     }),
     [currentRoute.id]
   );

--- a/client/app/components/empty-state/EmptyState.jsx
+++ b/client/app/components/empty-state/EmptyState.jsx
@@ -143,18 +143,6 @@ function EmptyState({
       ),
     },
     {
-      key: "alerts",
-      node: (
-        <Step
-          key="alerts"
-          show={isAvailable.alert}
-          completed={isCompleted.alert}
-          url="alerts/new"
-          urlText="Create your first Alert"
-        />
-      ),
-    },
-    {
       key: "users",
       node: (
         <Step

--- a/client/app/pages/alert/Alert.jsx
+++ b/client/app/pages/alert/Alert.jsx
@@ -78,7 +78,6 @@ class Alert extends React.Component {
         .then(alert => {
           if (this._isMounted) {
             const canEdit = currentUser.canEdit(alert)
-            // const canEdit = currentUser.canEdit(alert) && currentUser.hasPermission("create_alert")
 
             // force view mode if can't edit
             if (!canEdit) {
@@ -247,7 +246,7 @@ class Alert extends React.Component {
           {mode === MODES.VIEW && (
             <AlertView canEdit={canEdit} onEdit={this.edit} muted={muted} unmute={this.unmute} {...commonProps} />
           )}
-          {mode === MODES.EDIT && <AlertEdit cancel={this.cancel} {...commonProps} />}
+          {mode === MODES.EDIT && currentUser.hasPermission("create_alert") && <AlertEdit cancel={this.cancel} {...commonProps} />}
         </div>
       </div>
     );

--- a/client/app/pages/alert/Alert.jsx
+++ b/client/app/pages/alert/Alert.jsx
@@ -77,7 +77,8 @@ class Alert extends React.Component {
       AlertService.get({ id: alertId })
         .then(alert => {
           if (this._isMounted) {
-            const canEdit = currentUser.canEdit(alert) && currentUser.hasPermission("create_alerts")
+            const canEdit = currentUser.canEdit(alert)
+            // const canEdit = currentUser.canEdit(alert) && currentUser.hasPermission("create_alerts")
 
             // force view mode if can't edit
             if (!canEdit) {
@@ -242,7 +243,7 @@ class Alert extends React.Component {
     return (
       <div className="alert-page">
         <div className="container">
-          {mode === MODES.NEW && <AlertNew {...commonProps} />}
+          {mode === MODES.NEW && currentUser.hasPermission("create_alerts") && <AlertNew {...commonProps} />}
           {mode === MODES.VIEW && (
             <AlertView canEdit={canEdit} onEdit={this.edit} muted={muted} unmute={this.unmute} {...commonProps} />
           )}

--- a/client/app/pages/alert/Alert.jsx
+++ b/client/app/pages/alert/Alert.jsx
@@ -78,7 +78,7 @@ class Alert extends React.Component {
         .then(alert => {
           if (this._isMounted) {
             const canEdit = currentUser.canEdit(alert)
-            // const canEdit = currentUser.canEdit(alert) && currentUser.hasPermission("create_alerts")
+            // const canEdit = currentUser.canEdit(alert) && currentUser.hasPermission("create_alert")
 
             // force view mode if can't edit
             if (!canEdit) {
@@ -243,7 +243,7 @@ class Alert extends React.Component {
     return (
       <div className="alert-page">
         <div className="container">
-          {mode === MODES.NEW && currentUser.hasPermission("create_alerts") && <AlertNew {...commonProps} />}
+          {mode === MODES.NEW && currentUser.hasPermission("create_alert") && <AlertNew {...commonProps} />}
           {mode === MODES.VIEW && (
             <AlertView canEdit={canEdit} onEdit={this.edit} muted={muted} unmute={this.unmute} {...commonProps} />
           )}

--- a/client/app/pages/alert/Alert.jsx
+++ b/client/app/pages/alert/Alert.jsx
@@ -42,7 +42,7 @@ class Alert extends React.Component {
   static defaultProps = {
     mode: null,
     alertId: null,
-    onError: () => {},
+    onError: () => { },
   };
 
   _isMounted = false;
@@ -77,7 +77,7 @@ class Alert extends React.Component {
       AlertService.get({ id: alertId })
         .then(alert => {
           if (this._isMounted) {
-            const canEdit = currentUser.canEdit(alert);
+            const canEdit = currentUser.canEdit(alert) && currentUser.hasPermission("create_alerts")
 
             // force view mode if can't edit
             if (!canEdit) {

--- a/client/app/pages/alert/AlertView.jsx
+++ b/client/app/pages/alert/AlertView.jsx
@@ -20,6 +20,7 @@ import AlertDestinations from "./components/AlertDestinations";
 import HorizontalFormItem from "./components/HorizontalFormItem";
 import { STATE_CLASS } from "../alerts/AlertsList";
 import DynamicComponent from "@/components/DynamicComponent";
+import { currentUser } from "@/services/auth";
 
 function AlertState({ state, lastTriggered }) {
   return (
@@ -69,10 +70,10 @@ export default class AlertView extends React.Component {
         <Title name={name} alert={alert}>
           <DynamicComponent name="AlertView.HeaderExtra" alert={alert} />
           <Tooltip title={canEdit ? "" : "You do not have sufficient permissions to edit this alert"}>
-            <Button type="default" onClick={canEdit ? onEdit : null} className={cx({ disabled: !canEdit })}>
+            {currentUser.hasPermission("create_alert") && <Button type="default" onClick={canEdit ? onEdit : null} className={cx({ disabled: !canEdit })}>
               <i className="fa fa-edit m-r-5" aria-hidden="true" />
               Edit
-            </Button>
+            </Button>}
             {menuButton}
           </Tooltip>
         </Title>
@@ -118,7 +119,7 @@ export default class AlertView extends React.Component {
                     <>
                       Notifications for this alert will not be sent.
                       <br />
-                      {canEdit && (
+                      {canEdit && currentUser.hasPermission("create_alert") && (
                         <>
                           To restore notifications click
                           <Button

--- a/client/app/pages/alert/components/AlertDestinations.jsx
+++ b/client/app/pages/alert/components/AlertDestinations.jsx
@@ -187,7 +187,7 @@ export default class AlertDestinations extends React.Component {
 
     return (
       <div className="alert-destinations" data-test="AlertDestinations">
-        <Tooltip title='Click to add an existing "Alert Destination"' mouseEnterDelay={0.5}>
+        {currentUser.hasPermission("create_alert") && <Tooltip title='Click to add an existing "Alert Destination"' mouseEnterDelay={0.5}>
           <Button
             data-test="ShowAddAlertSubDialog"
             type="primary"
@@ -196,13 +196,13 @@ export default class AlertDestinations extends React.Component {
             onClick={this.showAddAlertSubDialog}>
             <i className="fa fa-plus f-12 m-r-5" aria-hidden="true" /> Add
           </Button>
-        </Tooltip>
+        </Tooltip>}
         <ul>
           <li className="destination-wrapper">
             <i className="destination-icon fa fa-envelope" aria-hidden="true" />
             <span className="flex-fill">{currentUser.email}</span>
             <EmailSettingsWarning className="destination-warning" featureName="alert emails" mode="icon" />
-            {!mailSettingsMissing && (
+            {!mailSettingsMissing && currentUser.hasPermission("create_alert") && (
               <Switch
                 size="small"
                 className="toggle-button"

--- a/client/app/pages/alert/components/AlertDestinations.jsx
+++ b/client/app/pages/alert/components/AlertDestinations.jsx
@@ -45,7 +45,7 @@ function ListItem({ destination: { name, type }, user, unsubscribe }) {
       {type === "email" && (
         <EmailSettingsWarning className="destination-warning" featureName="alert emails" mode="icon" />
       )}
-      {canUnsubscribe && (
+      {canUnsubscribe && currentUser.hasPermission("create_alert") && (
         <Tooltip title="Remove" mouseEnterDelay={0.5}>
           <PlainButton className="remove-button" onClick={unsubscribe}>
             {/* TODO: lacks visual feedback */}
@@ -202,7 +202,7 @@ export default class AlertDestinations extends React.Component {
             <i className="destination-icon fa fa-envelope" aria-hidden="true" />
             <span className="flex-fill">{currentUser.email}</span>
             <EmailSettingsWarning className="destination-warning" featureName="alert emails" mode="icon" />
-            {!mailSettingsMissing && currentUser.hasPermission("create_alert") && (
+            {!mailSettingsMissing && (
               <Switch
                 size="small"
                 className="toggle-button"
@@ -210,6 +210,7 @@ export default class AlertDestinations extends React.Component {
                 loading={!subs}
                 onChange={() => this.onUserEmailToggle(currentUserEmailSub)}
                 data-test="UserEmailToggle"
+                disabled={!currentUser.hasPermission("create_alert")}
               />
             )}
           </li>

--- a/client/app/pages/alert/components/MenuButton.jsx
+++ b/client/app/pages/alert/components/MenuButton.jsx
@@ -10,6 +10,7 @@ import Button from "antd/lib/button";
 import LoadingOutlinedIcon from "@ant-design/icons/LoadingOutlined";
 import EllipsisOutlinedIcon from "@ant-design/icons/EllipsisOutlined";
 import PlainButton from "@/components/PlainButton";
+import { currentUser } from "@/services/auth";
 
 export default function MenuButton({ doDelete, canEdit, mute, unmute, muted }) {
   const [loading, setLoading] = useState(false);
@@ -45,13 +46,13 @@ export default function MenuButton({ doDelete, canEdit, mute, unmute, muted }) {
       placement="bottomRight"
       overlay={
         <Menu>
-          <Menu.Item>
+          {currentUser.hasPermission("create_alert") && <Menu.Item>
             {muted ? (
               <PlainButton onClick={() => execute(unmute)}>Unmute Notifications</PlainButton>
             ) : (
               <PlainButton onClick={() => execute(mute)}>Mute Notifications</PlainButton>
             )}
-          </Menu.Item>
+          </Menu.Item>}
           <Menu.Item>
             <PlainButton onClick={confirmDelete}>Delete</PlainButton>
           </Menu.Item>

--- a/client/app/pages/alerts/AlertsList.jsx
+++ b/client/app/pages/alerts/AlertsList.jsx
@@ -86,7 +86,7 @@ class AlertsList extends React.Component {
           <PageHeader
             title={controller.params.pageTitle}
             actions={
-              currentUser.hasPermission("create_alerts") ? (
+              currentUser.hasPermission("create_alert") ? (
                 <Link.Button block type="primary" href="alerts/new">
                   <i className="fa fa-plus m-r-5" aria-hidden="true" />
                   New Alert

--- a/client/app/pages/alerts/AlertsList.jsx
+++ b/client/app/pages/alerts/AlertsList.jsx
@@ -86,7 +86,7 @@ class AlertsList extends React.Component {
           <PageHeader
             title={controller.params.pageTitle}
             actions={
-              currentUser.hasPermission("list_alerts") ? (
+              currentUser.hasPermission("create_alerts") ? (
                 <Link.Button block type="primary" href="alerts/new">
                   <i className="fa fa-plus m-r-5" aria-hidden="true" />
                   New Alert


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

## Related Tickets & Documents
### DNA-23591
**Problem**

- The users are able to create alerts on Redash via menu bar and alerts screen
- Currently there is not such permission for create_alerts, the creation and updation of alerts is mapped to generic. list_alerts permission

**Solution**

- Mapping Creation of Alerts to a new permission (non-existent) i.e create_alerts
- Disable creation of alerts via route alerts/new

**Technical Details**

- [x] Apply create_alert permission on new alert creation in `components/ApplicationArea/ApplicationLayout/DesktopNavbar.jsx `and `client/app/pages/alerts/AlertsList.jsx`
- [x] Map list_alerts permission to create_alerts in `client/app/pages/alerts/AlertsList.jsx`
- [x] Removing the menuItem "Create your first query" from component in `client/app/components/empty-state/EmptyState.jsx`
- [x] Disabling Edit, Mute/Unmute/Restore Notifications, Alert destination addition in View only mode in `MenuButton.jsx`, `AlertDestinations.jsx`, `AlertView.jsx`
- [x] Disabling AlertNew and AlertEdit modal in `Alert.jsx`

**Testing Steps**
- Create your first alert link should not appear for the user on Welcome page

**If create_alert permission is disabled:**
- The left menu **+Create** should not have **"Alerts"** in the list for creating an alert
- The Alerts list page should not display/allow **[+Alert]** creation of alert for the users
- The users should not be able to create alerts via route **[/alerts/new]**. A blank page should be displayed
- The user will not be able to edit, mute/unmute notification, and add/update alert destinations
- The user will only be able to delete an alert

**If create_alert permission is enabled:**
- All the above screens should allow user to create/edit alerts

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
BEFORE:
<img width="1796" alt="Screenshot 2025-04-14 at 5 38 35 PM" src="https://github.com/user-attachments/assets/d4dba57c-a1d7-4487-bcdd-eda5db4c81eb" />

<img width="1721" alt="Screenshot 2025-04-14 at 5 41 32 PM" src="https://github.com/user-attachments/assets/3c2b7c4d-7dee-4c2f-9f2f-31298eb540c0" />

<img width="1789" alt="Screenshot 2025-04-16 at 12 02 34 PM" src="https://github.com/user-attachments/assets/a5f2f675-ccbe-4713-9ed6-cba4a0194dec" />


AFTER:
<img width="1788" alt="Screenshot 2025-04-14 at 5 31 41 PM" src="https://github.com/user-attachments/assets/e1ced6ca-76a1-4315-9c15-cd59c39e53f8" />

<img width="1260" alt="Screenshot 2025-04-14 at 5 55 38 PM" src="https://github.com/user-attachments/assets/d0340d02-961b-49b7-9cfa-980ef40da379" />

<img width="1792" alt="Screenshot 2025-04-16 at 1 09 07 PM" src="https://github.com/user-attachments/assets/0049b17b-db47-43ec-bf06-5bc4b6475cb3" />




